### PR TITLE
Feat: Take inputs from one file only

### DIFF
--- a/packages/bacalhau/scripts/generateDummyContributor.ts
+++ b/packages/bacalhau/scripts/generateDummyContributor.ts
@@ -9,15 +9,7 @@ const definedAddresses: Array<Address> = [];
 
 const maxHours: number = 100;
 const contributors: number = 10;
-const destinationPath = path.join(__dirname, "../inputs/round_1/");
-const trustedSeedDestinationPath = path.join(
-  destinationPath,
-  "trustedSeed.json"
-);
-const previousRewardsDestinationPath = path.join(
-  destinationPath,
-  "previousRewards.json"
-);
+const destinationPath = path.join(__dirname, "../inputs/");
 const dataDestinationPath = path.join(destinationPath, "data.json");
 
 interface ContributionData {
@@ -52,13 +44,15 @@ const generate = (
   logResult(contributions);
   const data = {
     data: contributions,
+    trustedSeed: trustedSeed,
+    previousRewards: "ipfsCID"
   };
-  return { data, trustedSeed };
+  return { data };
 };
 
 const main = () => {
   logProgress("Generating Mock Contributions Data");
-  const { data, trustedSeed } = generate(
+  const { data } = generate(
     definedAddresses,
     maxHours,
     contributors
@@ -67,8 +61,6 @@ const main = () => {
   logProgress("Writing Mock Contribution data");
   checkAndCreateIfDoesntExist(destinationPath, "Mock Data Destination Path");
   writeJson(dataDestinationPath, data);
-  writeJson(trustedSeedDestinationPath, trustedSeed);
-  writeJson(previousRewardsDestinationPath, "ipfsCID");
   logSuccess("Mock Data written");
 };
 

--- a/packages/bacalhau/scripts/index.ts
+++ b/packages/bacalhau/scripts/index.ts
@@ -13,8 +13,6 @@ import {
   readDir,
   log,
   logError,
-  isDirectory,
-  filesExist,
   logSuccess,
 } from "./../utils/IO";
 import { getMerkleTree } from "../utils/merkleTree";
@@ -39,10 +37,9 @@ export function main(impactEvaluatorFunction: any) {
     logError("No input was found");
   } else {
       // check if directory contains necessary files
-      if (!filesExist(inputPath)) {
-        logError(`Cannot continue without necessary files`);
-        throw Error("Files doesn't exist");
-      }
+      log(`Using data from following file: ${contents[0]}`);
+
+      const input = readJson(`${inputPath}/${contents[0]}`);
 
       // execute
       // read data
@@ -57,24 +54,25 @@ export function main(impactEvaluatorFunction: any) {
       };
 
       // read data
-      for (const content of contents) {
+      const inputFileKeys = Object.keys(input)
+      for (const key of inputFileKeys) {
         try {
-          const parsedData = readJson(`${inputPath}/${content}`);
-          if (content.includes("data")) {
-            logSuccess("data found in ", content);
-            inputs.dataList.push(parsedData);
-          } else if (content.includes("trustedSeed")) {
-            logSuccess("trsusted seed found in ", content);
-            inputs.trustedSeedList.push(parsedData);
-          } else if (content.includes("previousRewards")) {
-            logSuccess("previousRewards found in ", content);
-            inputs.previousRewards = parsedData;
+          const keyData = input[key];
+          if (key.includes("data")) {
+            logSuccess("data found in ", key);
+            inputs.dataList.push({data: keyData});
+          } else if (key.includes("trustedSeed")) {
+            logSuccess("trsusted seed found in ", key);
+            inputs.trustedSeedList.push(keyData);
+          } else if (key.includes("previousRewards")) {
+            logSuccess("previousRewards found in ", key);
+            inputs.previousRewards = keyData;
           } else {
-            logError("Extra data found: ", content);
-            inputs.otherData?.push(parsedData);
+            logError("Extra data found: ", key);
+            inputs.otherData?.push(keyData);
           }
         } catch (e) {
-          logError(`Reading Inputs for ${content} failed`);
+          logError(`Reading Inputs for ${key} failed`);
           logError(e);
         }
       }

--- a/packages/bacalhau/shell/run_bacalhau.sh
+++ b/packages/bacalhau/shell/run_bacalhau.sh
@@ -12,8 +12,8 @@ LATEST_DOCKER_IMAGE_DIGEST=`awk -F',"digest":"|","os"' '{print $2}' <<< "$IMAGE_
 
 # Constants
 DOCKER_IMAGE=${DOCKER_NAME}/$IMAGE_NAME@$LATEST_DOCKER_IMAGE_DIGEST
-DEFAULT_HTTPS_URL=https://nftstorage.link/ipfs/bafybeihjfez2hb2i2bdpwkegxopzu6teqmgwnbxqhukjl7brmgwppipnwa
-DEFAULT_IPFS_CID=bafybeihjfez2hb2i2bdpwkegxopzu6teqmgwnbxqhukjl7brmgwppipnwa
+DEFAULT_HTTPS_URL=https://gateway.pinata.cloud/ipfs/QmfCM4tpAL5jQGdnjdkTXkeJDhpCs7kJDJYupyY88UhuPT
+DEFAULT_IPFS_CID=QmfCM4tpAL5jQGdnjdkTXkeJDhpCs7kJDJYupyY88UhuPT
 OUTPUT_FOLDER=results
 
 # create results directory
@@ -37,21 +37,17 @@ echo "Running Docker image on Bacalhau"
 if [ $INPUT_URL_TYPE == "A" -o $INPUT_URL_TYPE == "a" ]
 then
    # Read Input URL (HTTPS)
-    echo "Provide IPFS Input for data.json:"
+    echo "Provide IPFS Input:"
     read INPUT_DATA_CID
-    echo "Provide IPFS Input for trustedSeed.json:"
-    read INPUT_TRUSTED_CID
     echo "Running Docker Image on Bacalhau..."
-    JOB_OUTPUT=`bacalhau docker run --inputs $INPUT_DATA_CID --inputs $INPUT_TRUSTED_CID $DOCKER_IMAGE`
+    JOB_OUTPUT=`bacalhau docker run --inputs $INPUT_DATA_CID $DOCKER_IMAGE`
 elif [ $INPUT_URL_TYPE == "B" -o $INPUT_URL_TYPE == "b" ]
 then
    # Read Input URL (HTTPS)
-    echo "Provide HTTPs Input for data.json:"
+    echo "Provide HTTPs Input:"
     read INPUT_DATA_URL
-    echo "Provide HTTPs Input for trustedSeed.json:"
-    read INPUT_TRUSTED_URL
     echo "Running Docker Image on Bacalhau..."
-    JOB_OUTPUT=`bacalhau docker run -u $INPUT_DATA_URL -u $INPUT_TRUSTED_URL $DOCKER_IMAGE`
+    JOB_OUTPUT=`bacalhau docker run -u $INPUT_DATA_URL $DOCKER_IMAGE`
 elif [ $INPUT_URL_TYPE == "C" -o $INPUT_URL_TYPE == "c" ]
 then
    # Run docker image with no input
@@ -63,7 +59,7 @@ then
    # Run docker image with default HTTPs input
    echo "Default HTTPs Input"
    echo "Running Docker Image on Bacalhau..."
-   JOB_OUTPUT=`bacalhau docker run -u $DEFAULT_HTTPS_URL/data.json -u $DEFAULT_HTTPS_URL/trustedSeed.json $DOCKER_IMAGE`
+   JOB_OUTPUT=`bacalhau docker run -u $DEFAULT_HTTPS_URL $DOCKER_IMAGE`
 elif [ $INPUT_URL_TYPE == "E" -o $INPUT_URL_TYPE == "e" ]
 then
    # run docker image with default IPFS input

--- a/yarn.lock
+++ b/yarn.lock
@@ -3114,7 +3114,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/qs@npm:^6.2.31":
+"@types/qs@npm:^6.2.31, @types/qs@npm:^6.9.7":
   version: 6.9.7
   resolution: "@types/qs@npm:6.9.7"
   checksum: 7fd6f9c25053e9b5bb6bc9f9f76c1d89e6c04f7707a7ba0e44cc01f17ef5284adb82f230f542c2d5557d69407c9a40f0f3515e8319afd14e1e16b5543ac6cdba
@@ -4362,6 +4362,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:^0.21.1":
+  version: 0.21.4
+  resolution: "axios@npm:0.21.4"
+  dependencies:
+    follow-redirects: ^1.14.0
+  checksum: 44245f24ac971e7458f3120c92f9d66d1fc695e8b97019139de5b0cc65d9b8104647db01e5f46917728edfc0cfd88eb30fc4c55e6053eef4ace76768ce95ff3c
+  languageName: node
+  linkType: hard
+
 "axios@npm:^1.2.2":
   version: 1.2.2
   resolution: "axios@npm:1.2.2"
@@ -5070,7 +5079,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -5129,7 +5138,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:3.5.3, chokidar@npm:^3.4.0, chokidar@npm:^3.5.3":
+"chokidar@npm:3.5.3, chokidar@npm:^3.4.0, chokidar@npm:^3.5.2, chokidar@npm:^3.5.3":
   version: 3.5.3
   resolution: "chokidar@npm:3.5.3"
   dependencies:
@@ -6208,6 +6217,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"encode-utf8@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "encode-utf8@npm:1.0.3"
+  checksum: 550224bf2a104b1d355458c8a82e9b4ea07f9fc78387bc3a49c151b940ad26473de8dc9e121eefc4e84561cb0b46de1e4cd2bc766f72ee145e9ea9541482817f
+  languageName: node
+  linkType: hard
+
 "encoding@npm:^0.1.13":
   version: 0.1.13
   resolution: "encoding@npm:0.1.13"
@@ -7254,7 +7270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethers@npm:^5.4.6, ethers@npm:^5.5.4, ethers@npm:^5.6.8, ethers@npm:^5.7.2":
+"ethers@npm:^5.4.6, ethers@npm:^5.5.3, ethers@npm:^5.5.4, ethers@npm:^5.6.8, ethers@npm:^5.7.2":
   version: 5.7.2
   resolution: "ethers@npm:5.7.2"
   dependencies:
@@ -7598,7 +7614,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.12.1, follow-redirects@npm:^1.15.0":
+"fmix@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "fmix@npm:0.1.0"
+  dependencies:
+    imul: ^1.0.0
+  checksum: c465344d4f169eaf10d45c33949a1e7a633f09dba2ac7063ce8ae8be743df5979d708f7f24900163589f047f5194ac5fc2476177ce31175e8805adfa7b8fb7a4
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.12.1, follow-redirects@npm:^1.14.0, follow-redirects@npm:^1.15.0":
   version: 1.15.2
   resolution: "follow-redirects@npm:1.15.2"
   peerDependenciesMeta:
@@ -8649,6 +8674,13 @@ __metadata:
   bin:
     import-local-fixture: fixtures/cli.js
   checksum: bfcdb63b5e3c0e245e347f3107564035b128a414c4da1172a20dc67db2504e05ede4ac2eee1252359f78b0bfd7b19ef180aec427c2fce6493ae782d73a04cddd
+  languageName: node
+  linkType: hard
+
+"imul@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "imul@npm:1.0.1"
+  checksum: 6c2af3d5f09e2135e14d565a2c108412b825b221eb2c881f9130467f2adccf7ae201773ae8bcf1be169e2d090567a1fdfa9cf20d3b7da7b9cecb95b920ff3e52
   languageName: node
   linkType: hard
 
@@ -10581,6 +10613,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"match-all@npm:^1.2.6":
+  version: 1.2.6
+  resolution: "match-all@npm:1.2.6"
+  checksum: 3d4f16b8fd082f2fd10e362f4a8b71c62f8a767591b3db831ca2bdcf726337e9a64e4abc30e2ef053dc2bcfb875a9ed80bd78e006ad5ef11380a7158d0cb00e1
+  languageName: node
+  linkType: hard
+
 "match-sorter@npm:^6.0.2":
   version: 6.3.1
   resolution: "match-sorter@npm:6.3.1"
@@ -11090,6 +11129,17 @@ __metadata:
     glur: ^1.1.2
     object-assign: ^4.1.1
   checksum: 420d2090e4c9466c8195281011643a7087a3f8db9f7621fb19e13dce34d468d16f6e686625426efd4dbd1c9fa1cbc3c07ff634d9d9534dc6fa47b0849c2bcd69
+  languageName: node
+  linkType: hard
+
+"murmur-128@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "murmur-128@npm:0.2.1"
+  dependencies:
+    encode-utf8: ^1.0.2
+    fmix: ^0.1.0
+    imul: ^1.0.0
+  checksum: 94ff8b39bf1a1a7bde83b6d13f656bbe591e0a5b5ffe4384c39470120ab70e9eadf0af38557742a30d24421ddc63aea6bba1028a1d6b66553038ee86a660dd92
   languageName: node
   linkType: hard
 
@@ -11640,7 +11690,6 @@ __metadata:
     "@types/chai": ^4.3.4
     "@types/jest": ^29.2.4
     "@types/mocha": ^10.0.1
-    bacalhau: "workspace:*"
     chai: ^4.3.7
     dotenv: ^16.0.3
     ethers: ^5.7.2
@@ -12282,7 +12331,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.4.0, qs@npm:^6.7.0":
+"qs@npm:^6.4.0, qs@npm:^6.7.0, qs@npm:^6.9.4":
   version: 6.11.0
   resolution: "qs@npm:6.11.0"
   dependencies:


### PR DESCRIPTION
What I have done:
1. Docker image takes input from the very first file in `./inputs` directory. Doesn't check the file name.
2. Docker Image expects the file to contains data in following structure:
```sh
{
  "data": {},
  "trustedSeed": [],
  "previousRewards": "",
  "otherData": {},
}
```
4. Updated shell script to use another default URL and CID
5. Updated shell script to only accept one URI.
6. Dummy data is generated in one file.